### PR TITLE
Pipeline setup

### DIFF
--- a/pose_pipeline/utils/video_format.py
+++ b/pose_pipeline/utils/video_format.py
@@ -7,8 +7,9 @@ import os
 def compress(fn):
     import subprocess
 
-    _, temp = tempfile.mkstemp(suffix='.mp4')
+    fd, temp = tempfile.mkstemp(suffix='.mp4')
     subprocess.run(['ffmpeg', '-y', '-i', fn, '-c:v', 'libx264', '-b:v', '5M', temp])
+    os.close(fd)
     return temp
 
 

--- a/pose_pipeline/utils/visualization.py
+++ b/pose_pipeline/utils/visualization.py
@@ -1,6 +1,7 @@
 import os
 import cv2
 import tempfile
+import shutil
 import subprocess
 import numpy as np
 from tqdm import tqdm
@@ -103,9 +104,10 @@ def video_overlay(video, output_name, callback, downsample=4, codec='MP4V', blur
     cap.release()
 
     if compress:
-        _, temp = tempfile.mkstemp(suffix='.mp4')
+        fd, temp = tempfile.mkstemp(suffix='.mp4')
         subprocess.run(['ffmpeg', '-y', '-i', output_name, '-c:v', 'libx264', '-b:v', bitrate, temp])
-        subprocess.run(['mv', temp, output_name])
+        os.close(fd)
+        shutil.move(temp,output_name)
 
 
 def draw_keypoints(image, keypoints, radius=10, threshold=0.2, color=(255, 255, 255)):

--- a/pose_pipeline/wrappers/mmaction.py
+++ b/pose_pipeline/wrappers/mmaction.py
@@ -104,7 +104,8 @@ class TopDownPersonVideo(dj.Computed):
             image = bbox_fn(image, idx)
             return image
 
-        _, out_file_name = tempfile.mkstemp(suffix='.mp4')
+        fd, out_file_name = tempfile.mkstemp(suffix='.mp4')
+        os.close(fd)
         video_overlay(video, out_file_name, overlay_fn, downsample=1)
 
         key['output_video'] = out_file_name


### PR DESCRIPTION
This pull request addresses bugs that pop up between Windows/Linux. 

- When creating temp files, closing the file descriptor is required on Windows and will raise a permission error if it is not done. Linux does not have this requirement.
- The 'mv' command invoked using the subprocess command is not available on Windows so this has been shifted to shutil.move().
- A command to release cv2.VideoCapture() in the VideoInfo table was added (likely a similar situation to the tempfile file descriptor issue)