### PR TITLE
np.float -> float

### DIFF
--- a/pose_pipeline/wrappers/deep_sort_yolov4/deep_sort/detection_yolo.py
+++ b/pose_pipeline/wrappers/deep_sort_yolov4/deep_sort/detection_yolo.py
@@ -27,7 +27,7 @@ class Detection_YOLO(object):
     """
 
     def __init__(self, tlwh, confidence, cls):
-        self.tlwh = np.asarray(tlwh, dtype=np.float)
+        self.tlwh = np.asarray(tlwh, dtype=float)
         self.confidence = float(confidence)
         self.cls = cls
 

--- a/pose_pipeline/wrappers/deep_sort_yolov4/deep_sort/preprocessing.py
+++ b/pose_pipeline/wrappers/deep_sort_yolov4/deep_sort/preprocessing.py
@@ -37,7 +37,7 @@ def non_max_suppression(boxes, max_bbox_overlap, scores=None):
     if len(boxes) == 0:
         return []
 
-    boxes = boxes.astype(np.float)
+    boxes = boxes.astype(float)
     pick = []
 
     x1 = boxes[:, 0]


### PR DESCRIPTION
NumPy 1.20.0 changes np.int to just int along with other dtypes (https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations). This fixes that.